### PR TITLE
Update comment on flopper interface.

### DIFF
--- a/contracts/interfaces/IFlopper.sol
+++ b/contracts/interfaces/IFlopper.sol
@@ -18,7 +18,7 @@ interface IFlopper {
         uint48 end
     );
 
-    // DAI contract address
+    // DSS core accounting contract address
     function vat() external view returns (address);
     // MKR contract address
     function gem() external view returns (address);


### PR DESCRIPTION
`vat()` incorrectly mentioned that it returns the Dai contract. The Vat is dss core accounting and we don't want anyone to accidentally use this address for ERC20 interaction.