### PR TITLE
Add working coverage command

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,25 @@
+const package = require("./package.json");
+const shell = require("shelljs");
+const utils = require("solidity-coverage/plugins/resources/truffle.utils");
+
+module.exports = {
+  port: 8545,
+  skipFiles: ["mcd", "interfaces"],
+  client: require("ganache-cli"),
+  providerOptions: {
+    network_id: package.config.ganacheNetworkID,
+    default_balance_ether: package.config.etherBalance,
+    mnemonic: package.config.mnemonic
+  },
+  onServerReady: function() {
+    shell.exec("rm -rf build");
+  },
+  onCompileComplete: async function(config) {
+    shell.exec("yarn gen:contract-typings");
+    shell.exec("tsc -b");
+
+    // Work arounds
+    config.test_files = await utils.getTestFilePaths(config);
+    process.env.npm_package_config_mnemonic = package.config.mnemonic;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gen:contract-typings": "rm -f typings/contracts/* && typechain --target ethers --outDir typings/contracts './build/contracts/*.json'",
     "start": "./node_modules/.bin/ganache-cli --gasLimit 10000000 -e 10000 2>&1 > ganache-output.log & echo 'local chain started.'",
     "test": "tsc -b && truffle test --network ganache build/*.spec.js",
+    "coverage": "truffle run coverage --temp build --file='./build/*.spec.js'",
     "stop": "kill -9 \"$(ps -ax | grep -m1 '[n]ode ./node_modules/.bin/ganache-cli' | awk '{print $1;}')\" && echo 'local chain stopped.'",
     "prettier": "prettier --write"
   },


### PR DESCRIPTION
(Idk if this is useful, please close if not.) 

PR adds working `npm run coverage`.

There's an example html report at: http://inquisitive-north.surge.sh/syndicate/index.html

CLI output looks like this:
![Screen Shot 2020-03-18 at 4 49 15 PM](https://user-images.githubusercontent.com/7332026/77017746-7af23480-6938-11ea-8eb1-ebdfaeda0056.png)

(Warning: command modifies contents of the `typings/` folder)